### PR TITLE
Add isomer and isobar-related fields to METASPACE export

### DIFF
--- a/neutral_loss_report_beta_test_3.py
+++ b/neutral_loss_report_beta_test_3.py
@@ -62,10 +62,12 @@ if reprocess == True:
 
 #%% Helper functions for retrieving data from METASPACE
 
-ANNOTATION_FIELDS = ("sumFormula neutralLoss adduct mz msmScore fdrLevel offSample "
+ANNOTATION_FIELDS = ("sumFormula neutralLoss adduct mz msmScore fdrLevel offSample ion ionFormula "
                      "dataset { id } "
                      "possibleCompounds { information { databaseId } } "
-                     "isotopeImages { url maxIntensity totalIntensity }")
+                     "isotopeImages { url maxIntensity totalIntensity } "
+                     "isomers { ion } "
+                     "isobars { ion msmScore } ")
 
 
 def get_ion_images_for_analysis(img_ids, hotspot_percentile=99, max_size=None, max_mem_mb=2048):
@@ -170,6 +172,8 @@ def get_single_dataset_images(ds_id, fdr=0.5):
         dict(
             image=images[i],
             formula=ann['sumFormula'],
+            ion=ann['ion'],
+            ion_formula=ann['ionFormula'],
             neutral_loss=ann['neutralLoss'],
             adduct=ann['adduct'],
             msm=ann['msmScore'],
@@ -179,7 +183,9 @@ def get_single_dataset_images(ds_id, fdr=0.5):
             # intensity_max=ann['isotopeImages'][0]['maxIntensity'],
             # intensity_99th=ann['isotopeImages'][0]['totalIntensity'] * np.percentile(images[i][images[i] != 0], 99),
             intensity_avg=ann['isotopeImages'][0]['totalIntensity'] / np.count_nonzero(images[i]),
-        ) for i, ann in enumerate(anns)])
+            isobars=[isobar['ion'] for isobar in ann['isobars'] if isobar['msmScore'] > ann['msmScore']],
+            isomers=[isomer['ion'] for isomer in ann['isomers']],
+    ) for i, ann in enumerate(anns)])
     return anns_df, images, mask, h, w
 
 


### PR DESCRIPTION
This change adds several new fields to the output of `neutral_loss_report_beta_test_3.py`:

* `ion` - a string of `formula` + `neutral_loss` + `adduct` + polarity `+`/`-`, useful as a unique ID for annotations within the dataset, because `formula` by itself won't be unique due to neutral losses & adducts. 
    Example values: `C10H8N2O-H-`, `C19H16O6-H2O-H-`

* `ion_formula` - the "normalized" version of the `ion`, which is guaranteed to be the same between isomers. 
    Example values: `C10H7N2O-`, `C19H13O5`

* `isomers`: a list `ion`s of annotations found in this dataset that are isomeric to this annotation. 
    Example values: `[]`, `['C19H14O5-H-']`

* `isobars`: a list of `ion`s of annotations found in this dataset that are isobaric to this annotation. I've added this just in case we find a reason to check if this affects data quality in the future. 
    When there are isobaric annotations, generally the annotation with the higher MSM score out of the candidates is more likely to be correct. I've filtered this list so that the links are only one-directional - the lower quality annotation will have the higher quality annotation listed as an isobar, but not vice versa. This allows easier filtering later - if `isobars` is empty, then either there's no isobars, or this annotation is the most probable out of the isobars. If `isobars` isn't empty, then this is a lower-quality annotation. If this doesn't make sense, LMK.

* `ion_H2O`, `ion_formula_H2O`, `isomers_H2O`, `isobars_H2O`